### PR TITLE
Small documentation fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or
 First your need to initialize Pixel with your pixelId.
 
 ```typescript
-import Pixel, { Config } from '@framit/meta-pixel';
+import { Pixel, Config } from '@framit/meta-pixel';
 
 const config: Config = {
     pixelId: 'your-pixel-id',


### PR DESCRIPTION
`import Pixel, { Config } from '@framit/meta-pixel'` referenced in the README.md does not work as the package does not have a default export