### PR TITLE
Update pixel.ts to export the `Config` type.

### DIFF
--- a/src/pixel.ts
+++ b/src/pixel.ts
@@ -8,7 +8,7 @@ import {
 
 declare var fbq: MetaPixel.Fbq;
 
-type Config = {
+export type Config = {
   isDebugMode?: boolean;
   disablePushState?: boolean;
   allowDuplicatePageViews?: boolean;


### PR DESCRIPTION
This solves a type error when initializing the Pixel as described in the ReadMe:

```
import { Pixel, Config } from '@framit/meta-pixel';  // Config was not exported

const config: Config = { //...// }
Pixel.initialize(config);
```